### PR TITLE
fix loader appearance

### DIFF
--- a/components/loader.js
+++ b/components/loader.js
@@ -1,0 +1,9 @@
+import PulseLoader from "react-spinners/PulseLoader";
+
+export default function Loader() {
+  return (
+    <div>
+      <PulseLoader size={12} margin={4} className="opacity-40" />
+    </div>
+  );
+}

--- a/components/predictions.js
+++ b/components/predictions.js
@@ -3,7 +3,7 @@ import { Copy as CopyIcon, PlusCircle as PlusCircleIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { Fragment, useEffect, useRef, useState } from "react";
-import PulseLoader from "react-spinners/PulseLoader";
+import Loader from "components/loader";
 
 export default function Predictions({ predictions, submissionCount }) {
   const scrollRef = useRef(null);
@@ -23,7 +23,7 @@ export default function Predictions({ predictions, submissionCount }) {
       {submissionCount > Object.keys(predictions).length && (
         <div className="pb-10 mx-auto w-full text-center">
           <div className="pt-10" ref={scrollRef} />
-          <PulseLoader />
+          <Loader />
         </div>
       )}
 
@@ -78,7 +78,7 @@ export function Prediction({ prediction, showLinkToNewScribble = false }) {
             />
           ) : (
             <div className="grid h-full place-items-center">
-              <PulseLoader />
+              <Loader />
             </div>
           )}
         </div>


### PR DESCRIPTION
The loader was getting displayed vertically while the prediction was running:

![Screenshot 2023-02-16 at 11 06 09 PM](https://user-images.githubusercontent.com/2289/219573530-cc360216-0ada-42da-b8cc-4e8b9fe964aa.png)

This unifies the style and fixes it:

![Screenshot 2023-02-16 at 11 07 15 PM](https://user-images.githubusercontent.com/2289/219573768-ee34996f-a82f-47ee-84f3-6c294b268bce.png)
