### PR TITLE
Bypass Vercel's image optimization by using regular img tags

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "@next/next/no-img-element": "off"
+  }
 }

--- a/components/predictions.js
+++ b/components/predictions.js
@@ -67,14 +67,18 @@ export function Prediction({ prediction, showLinkToNewScribble = false }) {
     <div className="mt-6 mb-12">
       <div className="shadow-lg border my-5 p-5 bg-white flex">
         <div className="w-1/2 aspect-square relative border">
-          <Image src={prediction.input.image} alt="input scribble" fill />
+          <img
+            src={prediction.input.image}
+            alt="input scribble"
+            className="w-full aspect-square"
+          />
         </div>
         <div className="w-1/2 aspect-square relative">
           {prediction.output?.length ? (
-            <Image
+            <img
               src={prediction.output[prediction.output.length - 1]}
               alt="output image"
-              fill
+              className="w-full aspect-square"
             />
           ) : (
             <div className="grid h-full place-items-center">


### PR DESCRIPTION
This PR updates the app to use a plain old unoptimized`<img>` tag instead of the Next.js `<Image>` tag which does dynamic resizing.

Cool feature, but the Vercel image optimization is costing a fortune.