### PR TITLE
refactor app host resolution

### DIFF
--- a/lib/get-app-host.js
+++ b/lib/get-app-host.js
@@ -1,0 +1,13 @@
+// Hack to get the protocol and host from headers
+//
+// https://github.com/vercel/next.js/discussions/44527
+//
+// production:  https://scribblediffusion.com
+// staging:     https://branch-foo.vercel.app
+// dev:         http://localhost:3000
+
+export default function getAppHost(req) {
+  const protocol = req.headers.referer?.split("://")[0] || "http";
+  const appHost = `${protocol}://${req.headers.host}`;
+  return appHost;
+}

--- a/pages/api/og.js
+++ b/pages/api/og.js
@@ -1,6 +1,7 @@
 import { ImageResponse } from "@vercel/og";
 import { NextRequest } from "next/server";
 import Image from "next/image";
+import getAppHost from "lib/get-app-host";
 
 export const config = {
   runtime: "edge",
@@ -13,15 +14,10 @@ export default async function handler(req) {
   const predictionId = searchParams.get("id");
   let inputImageURL, outputImageURL;
 
-  // extract protocol and host from the request url, so we can call the local API
-  const url = new URL(req.url);
-  const protocol = url.protocol;
-  const host = url.host;
+  const appHost = getAppHost(req);
 
   if (predictionId) {
-    const response = await fetch(
-      `${protocol}//${host}/api/predictions/${predictionId}`
-    );
+    const response = await fetch(`${appHost}/api/predictions/${predictionId}`);
     const prediction = await response.json();
 
     if (response.status === 200) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -10,12 +10,9 @@ import Script from "next/script";
 import seeds from "lib/seeds";
 import pkg from "../package.json";
 import sleep from "lib/sleep";
+import getAppHost from "lib/get-app-host";
 
-const HOST = process.env.VERCEL_URL
-  ? `https://${process.env.VERCEL_URL}`
-  : "http://localhost:3000";
-
-export default function Home() {
+export default function Home({ appHost }) {
   const [error, setError] = useState(null);
   const [submissionCount, setSubmissionCount] = useState(0);
   const [predictions, setPredictions] = useState({});
@@ -93,7 +90,7 @@ export default function Home() {
         <meta property="og:description" content={pkg.appMetaDescription} />
         <meta
           property="og:image"
-          content={`${HOST}/og-b7xwc4g4wrdrtneilxnbngzvti.png`}
+          content={`${appHost}/og-b7xwc4g4wrdrtneilxnbngzvti.png`}
         />
         <title>{pkg.appName}</title>s
       </Head>
@@ -135,4 +132,9 @@ export default function Home() {
       <Script src="https://js.upload.io/upload-js-full/v1" />
     </div>
   );
+}
+
+export async function getServerSideProps({ req }) {
+  const appHost = getAppHost(req);
+  return { props: { appHost } };
 }

--- a/pages/scribbles/[id].js
+++ b/pages/scribbles/[id].js
@@ -1,8 +1,9 @@
 import { Prediction } from "components/predictions";
 import Head from "next/head";
 import pkg from "../../package.json";
+import getAppHost from "lib/get-app-host";
 
-export default function Scribble({ prediction, baseUrl }) {
+export default function Scribble({ prediction, appHost }) {
   return (
     <div>
       <Head>
@@ -15,7 +16,7 @@ export default function Scribble({ prediction, baseUrl }) {
         <meta property="og:description" content={prediction.input.prompt} />
         <meta
           property="og:image"
-          content={`${baseUrl}/api/og?id=${prediction.id}`}
+          content={`${appHost}/api/og?id=${prediction.id}`}
         />
       </Head>
       <main className="container max-w-[1024px] mx-auto p-5">
@@ -28,12 +29,9 @@ export default function Scribble({ prediction, baseUrl }) {
 // Use getServerSideProps to force Next.js to render the page on the server,
 // so the OpenGraph meta tags will have the proper URL at render time.
 export async function getServerSideProps({ req }) {
-  // Hack to get the protocol and host from headers:
-  // https://github.com/vercel/next.js/discussions/44527
-  const protocol = req.headers.referer?.split("://")[0] || "http";
+  const appHost = getAppHost(req);
   const predictionId = req.url.split("/")[2];
-  const baseUrl = `${protocol}://${req.headers.host}`;
-  const response = await fetch(`${baseUrl}/api/predictions/${predictionId}`);
+  const response = await fetch(`${appHost}/api/predictions/${predictionId}`);
   const prediction = await response.json();
-  return { props: { baseUrl, prediction } };
+  return { props: { appHost, prediction } };
 }


### PR DESCRIPTION
To render OpenGraph image tags, absolute URLs are required.

The app's schema and host are different in dev, staging, and production.

This PR moves host resolution into a reusable module for consistency.