### PR TITLE
Small fixes to `<head>`

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -86,7 +86,7 @@ export default function Home() {
   };
 
   return (
-    <div>
+    <>
       <Head>
         <title>{pkg.appName}</title>
         <meta name="description" content={pkg.appMetaDescription} />
@@ -133,6 +133,6 @@ export default function Home() {
       </main>
 
       <Script src="https://js.upload.io/upload-js-full/v1" />
-    </div>
+    </>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -95,7 +95,7 @@ export default function Home() {
           property="og:image"
           content={`${HOST}/og-b7xwc4g4wrdrtneilxnbngzvti.png`}
         />
-        <title>{pkg.appName}</title>s
+        <title>{pkg.appName}</title>
       </Head>
       <main className="container max-w-[1024px] mx-auto p-5 ">
         <div className="container max-w-[512px] mx-auto">

--- a/pages/index.js
+++ b/pages/index.js
@@ -88,6 +88,7 @@ export default function Home() {
   return (
     <div>
       <Head>
+        <title>{pkg.appName}</title>
         <meta name="description" content={pkg.appMetaDescription} />
         <meta property="og:title" content={pkg.appName} />
         <meta property="og:description" content={pkg.appMetaDescription} />
@@ -95,7 +96,6 @@ export default function Home() {
           property="og:image"
           content={`${HOST}/og-b7xwc4g4wrdrtneilxnbngzvti.png`}
         />
-        <title>{pkg.appName}</title>
       </Head>
       <main className="container max-w-[1024px] mx-auto p-5 ">
         <div className="container max-w-[512px] mx-auto">


### PR DESCRIPTION
- Removes stray "s" character outside `<title>`
- Moves `<title>` above other meta characters
- Uses fragment (`<>`) for top-level container 