### PR TITLE
Use newer version of replicate/replicate-javascript and update API ca…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "scribble-diffusion",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "^4.10.1",
         "@vercel/analytics": "^0.1.10",
@@ -21,7 +22,7 @@
         "react-sketch-canvas": "^6.2.0",
         "react-spinners": "^0.13.8",
         "react-tooltip": "^5.13.0",
-        "replicate": "github:replicate/replicate-javascript#deployments",
+        "replicate": "github:replicate/replicate-javascript",
         "upload-js-full": "^1.22.0"
       },
       "devDependencies": {
@@ -3559,9 +3560,15 @@
       }
     },
     "node_modules/replicate": {
-      "version": "0.12.1",
-      "resolved": "git+ssh://git@github.com/replicate/replicate-javascript.git#632321066a37ef00413bda29b004e02ade31197d",
-      "license": "Apache-2.0"
+      "version": "0.16.0",
+      "resolved": "git+ssh://git@github.com/replicate/replicate-javascript.git#07dbb5bc3d7215a6ee194904ba71d196b9cf6f66",
+      "license": "Apache-2.0",
+      "engines": {
+        "git": ">=2.11.0",
+        "node": ">=18.0.0",
+        "npm": ">=7.19.0",
+        "yarn": ">=1.7.0"
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.2",
@@ -6794,8 +6801,8 @@
       "dev": true
     },
     "replicate": {
-      "version": "git+ssh://git@github.com/replicate/replicate-javascript.git#632321066a37ef00413bda29b004e02ade31197d",
-      "from": "replicate@github:replicate/replicate-javascript#deployments"
+      "version": "git+ssh://git@github.com/replicate/replicate-javascript.git#07dbb5bc3d7215a6ee194904ba71d196b9cf6f66",
+      "from": "replicate@github:replicate/replicate-javascript"
     },
     "resolve": {
       "version": "1.22.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-sketch-canvas": "^6.2.0",
     "react-spinners": "^0.13.8",
     "react-tooltip": "^5.13.0",
-    "replicate": "github:replicate/replicate-javascript#deployments",
+    "replicate": "github:replicate/replicate-javascript",
     "upload-js-full": "^1.22.0"
   },
   "devDependencies": {

--- a/pages/api/predictions/index.js
+++ b/pages/api/predictions/index.js
@@ -16,7 +16,12 @@ async function getObjectFromRequestBodyStream(body) {
 
 const WEBHOOK_HOST = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
-  : process.env.NGROK_HOST;
+  : (process.env.NGROK_HOST ? process.env.NGROK_HOST : `http://localhost:3000`) ;
+
+// Specify the model version to use
+const REPLICATE_MODEL_VERSION = process.env.REPLICATE_MODEL_VERSION 
+  ? process.env.REPLICATE_MODEL_VERSION 
+  : '795433b19458d0f4fa172a7ccf93178d2adb1cb8ab2ad6c8fdc33fdbcd49f477';
 
 export default async function handler(req) {
   if (!process.env.REPLICATE_API_TOKEN) {
@@ -33,10 +38,9 @@ export default async function handler(req) {
     auth: process.env.REPLICATE_API_TOKEN,
   });
 
-  const prediction = await replicate.deployments.predictions.create(
-    "replicate",
-    "scribble-diffusion-jagilley-controlnet",
+  const prediction = await replicate.predictions.create(
     {
+      version: REPLICATE_MODEL_VERSION,
       input,
       webhook: `${WEBHOOK_HOST}/api/replicate-webhook`,
       webhook_events_filter: ["start", "completed"],


### PR DESCRIPTION
Hi, I was receiving 500 errors when running the app, this commit fixes it for me - hopefully fixes for others too.

I pulled in a newer version of the replicate-javascript API and updated the API call params to reflect the changes.  Used newest model version from https://replicate.com/rossjillian/controlnet for API call.

Also added in a basic default base URL for WEBHOOK_HOST as the API complains about this being an invalid URL if neither VERCEL_URL or NGROK_HOST are set. 