### PR TITLE
allow images from pbxt.replicate.delivery

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
     domains: [
       "replicate.com",
       "replicate.delivery",
+      "pbxt.replicate.delivery",
       "user-images.githubusercontent.com",
       "upcdn.io"
     ],

--- a/next.config.js
+++ b/next.config.js
@@ -3,12 +3,27 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   images: {
-    domains: [
-      "replicate.com",
-      "replicate.delivery",
-      "pbxt.replicate.delivery",
-      "user-images.githubusercontent.com",
-      "upcdn.io"
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "replicate.com",
+      },
+      {
+        protocol: "https",
+        hostname: "replicate.delivery",
+      },
+      {
+        protocol: "https",
+        hostname: "*.replicate.delivery",
+      },
+      {
+        protocol: "https",
+        hostname: "user-images.githubusercontent.com",
+      },
+      {
+        protocol: "https",
+        hostname: "upcdn.io",
+      },
     ],
   },
   async redirects() {
@@ -22,9 +37,9 @@ const nextConfig = {
         source: "/deploy",
         destination: "https://vercel.com/templates/next.js/scribble-diffusion",
         permanent: false,
-      },   
-    ]
-  }
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
see https://github.com/replicate/inpainter/pull/29

Also switching from `domains` to `remotePatterns`. From the Next.js docs:

> Warning: We recommend configuring strict [remotePatterns](https://nextjs.org/docs/app/api-reference/components/image#remotepatterns) instead of domains in order to protect your application from malicious users. Only use domains if you own all the content served from the domain.