### PR TITLE
default to public model and make deployments opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,8 @@ DATABASE_URL=
 # 
 # e.g. https://8db01fea81ad.ngrok.io 
 NGROK_HOST=
+
+
+# Optional: Set a value for this to run the private Replicate deployment of the model
+# instead of the public ControlNet Scribble model.
+USE_REPLICATE_DEPLOYMENT=


### PR DESCRIPTION
TLDR: Make it possible for anyone to run this app again using a public Scribble model.

Backstory: In https://github.com/replicate/scribble-diffusion/pull/66, I updated the code to make requests to a private Replicate deployment, instead of the publicly accessible ControlNet Scribble model. I made this change to give us more control over scaling behavior of the model and the hardware it uses. The problem is that the new deployment is not publicly accessible, so anyone who cloned this repo and tried to run it encountered an error. This PR fixes that by defaulting to the public model unless an env var is set.

Speaking of that env var, I've added it to the Vercel production app, so this should be ready to go:

![Screenshot 2023-09-25 at 2 19 12 PM](https://github.com/replicate/scribble-diffusion/assets/2289/07d5d5b9-7384-4869-8873-1360a1433da3)

Resolves https://github.com/replicate/scribble-diffusion/issues/68

cc @replicate/hackers @replicate/product 