### PR TITLE
ci: enable npm caching in GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
+          cache: npm
       - run: npm ci
       - run: npm test


### PR DESCRIPTION
## Summary

- Add npm caching to actions/setup-node step
- Upgrade actions/setup-node from v3 to v4

## Benefits

This will speed up CI runs by caching node_modules between workflow runs, reducing install times and improving developer experience.

## Test plan

- [x] Verified workflow syntax is valid
- [ ] CI workflows will run faster on subsequent runs after this merge